### PR TITLE
Add navigation, FAQ and fix Python example

### DIFF
--- a/1-getting-started-with-ollama.md
+++ b/1-getting-started-with-ollama.md
@@ -3,6 +3,14 @@ layout: default
 title: "Part 1: Getting Started with Ollama"
 ---
 
+## Table of Contents
+
+- [What is Ollama?](#what-is-ollama)
+- [Installation](#installation)
+- [Example](#example)
+- [Conclusion](#conclusion)
+- [Other Details](#other-details)
+
 ## What is Ollama?
 
 Ollama is a powerful tool that allows you to run open-source large language models, such as Llama 3, Gemma, and others, directly on your own computer. This provides several benefits, including:

--- a/2-ollama-with-python.md
+++ b/2-ollama-with-python.md
@@ -3,6 +3,17 @@ layout: default
 title: "Part 2: Ollama with Python"
 ---
 
+## Table of Contents
+
+- [Interacting with Ollama Programmatically](#interacting-with-ollama-programmatically)
+- [Setting up the Python Environment](#setting-up-the-python-environment)
+- [Basic Interaction - Chat vs Generate](#basic-interaction---chat-vs-generate)
+- [Streaming Responses](#streaming-responses)
+- [Configuration Options](#configuration-options)
+- [Structured Output with Pydantic](#structured-output-with-pydantic)
+- [Tool Calling](#tool-calling)
+- [Conclusion](#conclusion)
+
 ## Interacting with Ollama Programmatically
 
 The `ollama` Python library provides a simple way to interact with Ollama programmatically.

--- a/3-vector-stores-with-qdrant.md
+++ b/3-vector-stores-with-qdrant.md
@@ -3,6 +3,18 @@ layout: default
 title: "Part 3: Vector Stores with Qdrant"
 ---
 
+## Table of Contents
+
+- [Introduction to Qdrant](#introduction-to-qdrant)
+- [Setting up Qdrant](#setting-up-qdrant)
+- [Option 1: Running Qdrant as a Server with Docker](#option-1-running-qdrant-as-a-server-with-docker)
+- [Option 2: Running Qdrant Locally](#option-2-running-qdrant-locally)
+- [Using Qdrant with Python](#using-qdrant-with-python)
+- [Creating a Collection](#creating-a-collection)
+- [Example using IBM's Granite Embedding Models](#example-using-ibms-granite-embedding-models)
+- [Searching the Collection (Retrieval)](#searching-the-collection-retrieval)
+- [Conclusion](#conclusion)
+
 ### Introduction to Qdrant
 
 Qdrant is a high-performance, open-source vector database that is well-suited for building RAG applications. It offers both a server-based version for production use and a lightweight local mode for development and smaller projects.

--- a/4-rag-with-langchain.md
+++ b/4-rag-with-langchain.md
@@ -3,6 +3,14 @@ layout: default
 title: "Part 4: RAG with Langchain"
 ---
 
+## Table of Contents
+
+- [What is Langchain?](#what-is-langchain)
+- [Setting up the Langchain Environment](#setting-up-the-langchain-environment)
+- [Building a RAG Pipeline](#building-a-rag-pipeline)
+- [Full RAG Script](#full-rag-script)
+- [How it Works](#how-it-works)
+
 ### What is Langchain?
 
 Langchain is a framework designed to simplify the development of applications powered by large language models. It provides the "glue" that connects our different components—the LLM, the vector database, and our application logic—into a coherent pipeline.

--- a/5-advanced-concepts.md
+++ b/5-advanced-concepts.md
@@ -3,6 +3,10 @@ layout: default
 title: "Part 5: Advanced Concepts"
 ---
 
+## Table of Contents
+
+- [Advanced Concepts](#advanced-concepts)
+
 ## Advanced Concepts
 
 This section will cover more advanced techniques, such as creating agentic workflows with tool use, function calling, and building more complex RAG pipelines.

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: FAQ
+---
+
+## Frequently Asked Questions
+
+### Which model fits in 8GB RAM?
+A smaller model such as `llama3:8b` usually works on a machine with 8GB of RAM.
+
+### How do I update my local models?
+Run `ollama pull <model_name>` to download the latest version.
+
+### Ollama command not found
+Make sure the Ollama executable is in your `PATH` and restart your terminal after installation.
+
+### Qdrant server failed to start
+Verify that Docker is running and ports `6333` and `6334` are free.
+
+### Where can I report bugs?
+Please open an issue on the [project's GitHub repository](https://github.com/your/repo/issues).

--- a/index.md
+++ b/index.md
@@ -7,6 +7,15 @@ title: Home
 
 This guide is designed to help you get started with local AI development.
 
+## Table of Contents
+
+- [Part 1: Getting Started with Ollama](1-getting-started-with-ollama.html)
+- [Part 2: Ollama with Python](2-ollama-with-python.html)
+- [Part 3: Vector Stores with Qdrant](3-vector-stores-with-qdrant.html)
+- [Part 4: RAG with Langchain](4-rag-with-langchain.html)
+- [Part 5: Advanced Concepts](5-advanced-concepts.html)
+- [FAQ](faq.html)
+
 ## What You'll Learn
 
 - **Part 1: Getting Started with Ollama:** How to install and run local LLMs.

--- a/scripts/OllamaBasics/ollamaBasics.py
+++ b/scripts/OllamaBasics/ollamaBasics.py
@@ -59,4 +59,4 @@ response = ollama.generate(
     }
 )
 print("\nOptions response, temperature=2:")
-print(response['response']
+print(response['response'])  # Example output will vary


### PR DESCRIPTION
## Summary
- add TOC with links on the home page
- add local tables of contents for each part
- create a troubleshooting/FAQ page
- repair the ollamaBasics example script

## Testing
- `python3 -m py_compile scripts/OllamaBasics/ollamaBasics.py`

------
https://chatgpt.com/codex/tasks/task_e_6844bd3483288327b69fd99cd9162aef